### PR TITLE
Correct sending identifiers

### DIFF
--- a/server/webhook.lua
+++ b/server/webhook.lua
@@ -73,7 +73,14 @@ function Webhook(webHookUrl, webHookImage)
     end
 
     self.getPlayerServerInfo = function ()
-        local user = {}
+        local user = {
+            steamhex = "None",
+            license = "None",
+            xbox = "None",
+            ip = "None",
+            discord = "None",
+            microsoft = "None"
+        }
         user.name = GetPlayerName(source)
 
         for k,v in pairs(GetPlayerIdentifiers(source)) do              


### PR DESCRIPTION
Fix problem when player don´t have one identifier. Of an identifier missing can't send message.